### PR TITLE
Add "New" badge for auto-discovered IPs + fix badge colors

### DIFF
--- a/netbox_ping/__init__.py
+++ b/netbox_ping/__init__.py
@@ -5,7 +5,7 @@ class NetBoxPingConfig(PluginConfig):
     name = 'netbox_ping'
     verbose_name = 'NetBox Ping'
     description = 'Ping and discover IP addresses in NetBox'
-    version = '2.2.1'
+    version = '2.3.0'
     author = 'Christian Rose'
     base_url = 'netbox-ping'
     min_version = '4.5.0'

--- a/netbox_ping/api/serializers.py
+++ b/netbox_ping/api/serializers.py
@@ -7,6 +7,7 @@ class PingResultSerializer(NetBoxModelSerializer):
         model = PingResult
         fields = (
             'id', 'url', 'display', 'ip_address', 'is_reachable',
+            'is_new', 'discovered_at',
             'last_seen', 'response_time_ms', 'dns_name', 'last_checked',
             'tags', 'custom_fields', 'created', 'last_updated',
         )
@@ -29,7 +30,7 @@ class SubnetScanResultSerializer(NetBoxModelSerializer):
         model = SubnetScanResult
         fields = (
             'id', 'url', 'display', 'prefix', 'total_hosts', 'hosts_up',
-            'hosts_down', 'last_scanned', 'last_discovered',
+            'hosts_down', 'hosts_new', 'last_scanned', 'last_discovered',
             'tags', 'custom_fields', 'created', 'last_updated',
         )
         brief_fields = ('id', 'url', 'display', 'prefix', 'hosts_up', 'total_hosts')

--- a/netbox_ping/filtersets.py
+++ b/netbox_ping/filtersets.py
@@ -8,6 +8,7 @@ class PingResultFilterSet(NetBoxModelFilterSet):
     is_reachable = django_filters.BooleanFilter()
     is_skipped = django_filters.BooleanFilter()
     is_stale = django_filters.BooleanFilter()
+    is_new = django_filters.BooleanFilter()
     dns_name = django_filters.CharFilter(lookup_expr='icontains')
     last_checked_before = django_filters.DateTimeFilter(
         field_name='last_checked', lookup_expr='lte',
@@ -18,7 +19,7 @@ class PingResultFilterSet(NetBoxModelFilterSet):
 
     class Meta:
         model = PingResult
-        fields = ('id', 'is_reachable', 'is_skipped', 'is_stale', 'dns_name', 'ip_address')
+        fields = ('id', 'is_reachable', 'is_skipped', 'is_stale', 'is_new', 'dns_name', 'ip_address')
 
     def search(self, queryset, name, value):
         if not value.strip():

--- a/netbox_ping/forms.py
+++ b/netbox_ping/forms.py
@@ -10,7 +10,7 @@ class PingResultFilterForm(NetBoxModelFilterSetForm):
     model = PingResult
     fieldsets = (
         FieldSet('q', 'filter_id'),
-        FieldSet('is_reachable', 'is_stale', name='Status'),
+        FieldSet('is_reachable', 'is_stale', 'is_new', name='Status'),
     )
     is_reachable = forms.NullBooleanField(
         required=False,
@@ -24,6 +24,15 @@ class PingResultFilterForm(NetBoxModelFilterSetForm):
     is_stale = forms.NullBooleanField(
         required=False,
         label='Stale',
+        widget=forms.Select(choices=[
+            ('', '---------'),
+            ('true', 'Yes'),
+            ('false', 'No'),
+        ]),
+    )
+    is_new = forms.NullBooleanField(
+        required=False,
+        label='New',
         widget=forms.Select(choices=[
             ('', '---------'),
             ('true', 'Yes'),
@@ -74,6 +83,7 @@ class PluginSettingsForm(NetBoxModelForm):
             'ping_concurrency', 'ping_timeout', 'skip_reserved_ips',
             'stale_enabled', 'stale_scans_threshold', 'stale_days_threshold',
             'stale_remove_enabled', 'stale_remove_days',
+            'new_ip_days_threshold',
             'email_notifications_enabled', 'email_recipients',
             'email_digest_interval', 'email_include_details',
             'email_utilization_threshold', 'email_on_change_only',

--- a/netbox_ping/jobs.py
+++ b/netbox_ping/jobs.py
@@ -288,11 +288,25 @@ class AutoScanDispatcherJob(JobRunner):
                 print(f'[Dispatcher] Trimmed {deleted} history records', flush=True)
 
         # Prune old ScanEvent records (older than 7 days)
-        from .models import ScanEvent
+        from .models import ScanEvent, PingResult as PingResultModel
         cutoff = now - timedelta(days=7)
         pruned = ScanEvent.objects.filter(created_at__lt=cutoff).delete()[0]
         if pruned:
             print(f'[Dispatcher] Pruned {pruned} old scan event(s)', flush=True)
+
+        # Expire "New" badges
+        new_days = settings.new_ip_days_threshold
+        if new_days > 0:
+            expiry_cutoff = now - timedelta(days=new_days)
+            expired_new = PingResultModel.objects.filter(
+                is_new=True, discovered_at__lt=expiry_cutoff,
+            ).update(is_new=False)
+            if expired_new:
+                print(f'[Dispatcher] Expired "New" badge on {expired_new} IP(s)', flush=True)
+        elif new_days == 0:
+            cleared = PingResultModel.objects.filter(is_new=True).update(is_new=False)
+            if cleared:
+                print(f'[Dispatcher] Cleared {cleared} "New" badge(s) (feature disabled)', flush=True)
 
         print('[Dispatcher] Done', flush=True)
 

--- a/netbox_ping/migrations/0013_new_ip_badge.py
+++ b/netbox_ping/migrations/0013_new_ip_badge.py
@@ -1,0 +1,31 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('netbox_ping', '0012_stale_ip_detection'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='pingresult',
+            name='is_new',
+            field=models.BooleanField(default=False, help_text='IP was recently auto-discovered', verbose_name='New'),
+        ),
+        migrations.AddField(
+            model_name='pingresult',
+            name='discovered_at',
+            field=models.DateTimeField(blank=True, help_text='When this IP was first auto-discovered', null=True, verbose_name='Discovered At'),
+        ),
+        migrations.AddField(
+            model_name='pluginsettings',
+            name='new_ip_days_threshold',
+            field=models.PositiveIntegerField(default=7, help_text='Show "New" badge on auto-discovered IPs for this many days (0 = disabled)', verbose_name='New IP Badge Duration (days)'),
+        ),
+        migrations.AddField(
+            model_name='subnetscanresult',
+            name='hosts_new',
+            field=models.IntegerField(default=0),
+        ),
+    ]

--- a/netbox_ping/models.py
+++ b/netbox_ping/models.py
@@ -91,6 +91,17 @@ class PingResult(NetBoxModel):
         verbose_name='Stale',
         help_text='IP has been unreachable beyond the configured stale threshold',
     )
+    is_new = models.BooleanField(
+        default=False,
+        verbose_name='New',
+        help_text='IP was recently auto-discovered',
+    )
+    discovered_at = models.DateTimeField(
+        blank=True,
+        null=True,
+        verbose_name='Discovered At',
+        help_text='When this IP was first auto-discovered',
+    )
 
     class Meta:
         ordering = ['-last_checked']
@@ -106,6 +117,8 @@ class PingResult(NetBoxModel):
             status = 'Up'
         else:
             status = 'Down'
+        if self.is_new:
+            status += ' (New)'
         return f'{self.ip_address} — {status}'
 
     def get_absolute_url(self):
@@ -132,6 +145,7 @@ class SubnetScanResult(NetBoxModel):
     hosts_down = models.IntegerField(default=0)
     hosts_skipped = models.IntegerField(default=0)
     hosts_stale = models.IntegerField(default=0)
+    hosts_new = models.IntegerField(default=0)
     last_scanned = models.DateTimeField(
         blank=True,
         null=True,
@@ -402,6 +416,13 @@ class PluginSettings(models.Model):
         default=30,
         verbose_name='Remove After Days',
         help_text='Delete IP from NetBox after this many days since last seen online',
+    )
+
+    # ── New IP Badge ──
+    new_ip_days_threshold = models.PositiveIntegerField(
+        default=7,
+        verbose_name='New IP Badge Duration (days)',
+        help_text='Show "New" badge on auto-discovered IPs for this many days (0 = disabled)',
     )
 
     class Meta:

--- a/netbox_ping/tables.py
+++ b/netbox_ping/tables.py
@@ -7,13 +7,16 @@ from .models import PingResult, PingHistory, SubnetScanResult, DnsHistory
 
 PINGRESULT_STATUS_TEMPLATE = '''
 {% if record.is_skipped %}
-    <span class="badge text-bg-light text-dark">Skipped</span>
+    <span class="badge text-bg-warning">Skipped</span>
 {% elif record.is_stale %}
-    <span class="badge text-bg-warning">Stale</span>
+    <span class="badge" style="background-color:#e67e22;color:#fff;">Stale</span>
 {% elif record.is_reachable %}
     <span class="badge text-bg-success">Up</span>
 {% else %}
     <span class="badge text-bg-danger">Down</span>
+{% endif %}
+{% if record.is_new %}
+    <span class="badge text-bg-info">New</span>
 {% endif %}
 '''
 
@@ -133,6 +136,7 @@ class SubnetScanResultTable(NetBoxTable):
     hosts_down = tables.Column(verbose_name='Hosts Down')
     hosts_skipped = tables.Column(verbose_name='Hosts Skipped')
     hosts_stale = tables.Column(verbose_name='Hosts Stale')
+    hosts_new = tables.Column(verbose_name='Hosts New')
     last_scanned = tables.DateTimeColumn(verbose_name='Last Scanned')
     last_discovered = tables.DateTimeColumn(verbose_name='Last Discovered')
     actions = columns.ActionsColumn(
@@ -143,10 +147,10 @@ class SubnetScanResultTable(NetBoxTable):
         model = SubnetScanResult
         fields = (
             'pk', 'id', 'prefix', 'total_hosts', 'hosts_up',
-            'hosts_down', 'hosts_skipped', 'hosts_stale', 'last_scanned', 'last_discovered', 'actions',
+            'hosts_down', 'hosts_skipped', 'hosts_stale', 'hosts_new', 'last_scanned', 'last_discovered', 'actions',
         )
         default_columns = (
-            'prefix', 'total_hosts', 'hosts_up', 'hosts_down', 'hosts_skipped', 'hosts_stale', 'last_scanned',
+            'prefix', 'total_hosts', 'hosts_up', 'hosts_down', 'hosts_skipped', 'hosts_stale', 'hosts_new', 'last_scanned',
         )
 
 
@@ -170,11 +174,14 @@ PING_STATUS_TEMPLATE = '''
     {% if record.ping_result.is_skipped %}
         <span class="badge text-bg-warning">Skipped</span>
     {% elif record.ping_result.is_stale %}
-        <span class="badge text-bg-warning">Stale</span>
+        <span class="badge" style="background-color:#e67e22;color:#fff;">Stale</span>
     {% elif record.ping_result.is_reachable %}
         <span class="badge text-bg-success">Up</span>
     {% else %}
         <span class="badge text-bg-danger">Down</span>
+    {% endif %}
+    {% if record.ping_result.is_new %}
+        <span class="badge text-bg-info">New</span>
     {% endif %}
 {% else %}
     <span class="text-muted">&mdash;</span>
@@ -186,8 +193,11 @@ SCAN_STATUS_TEMPLATE = '''
     <span class="badge text-bg-info">
         {{ record.scan_result.hosts_up }}/{{ record.scan_result.total_hosts }} up
     </span>
+    {% if record.scan_result.hosts_new %}
+        <span class="badge text-bg-info">{{ record.scan_result.hosts_new }} new</span>
+    {% endif %}
     {% if record.scan_result.hosts_stale %}
-        <span class="badge text-bg-warning">{{ record.scan_result.hosts_stale }} stale</span>
+        <span class="badge" style="background-color:#e67e22;color:#fff;">{{ record.scan_result.hosts_stale }} stale</span>
     {% endif %}
     {% if record.scan_result.hosts_skipped %}
         <span class="badge text-bg-warning">{{ record.scan_result.hosts_skipped }} skipped</span>

--- a/netbox_ping/templates/netbox_ping/inc/ipaddress_ping_panel.html
+++ b/netbox_ping/templates/netbox_ping/inc/ipaddress_ping_panel.html
@@ -8,10 +8,17 @@
       <tr>
         <th scope="row">Status</th>
         <td>
-          {% if ping_result.is_reachable %}
+          {% if ping_result.is_skipped %}
+            <span class="badge text-bg-warning">Skipped</span>
+          {% elif ping_result.is_stale %}
+            <span class="badge" style="background-color:#e67e22;color:#fff;">Stale</span>
+          {% elif ping_result.is_reachable %}
             <span class="badge text-bg-success">Up</span>
           {% else %}
             <span class="badge text-bg-danger">Down</span>
+          {% endif %}
+          {% if ping_result.is_new %}
+            <span class="badge text-bg-info">New</span>
           {% endif %}
         </td>
       </tr>

--- a/netbox_ping/templates/netbox_ping/inc/prefix_scan_panel.html
+++ b/netbox_ping/templates/netbox_ping/inc/prefix_scan_panel.html
@@ -13,6 +13,12 @@
         <th scope="row">Hosts Down</th>
         <td><span class="badge text-bg-danger">{{ scan_result.hosts_down }}</span></td>
       </tr>
+      {% if scan_result.hosts_new %}
+      <tr>
+        <th scope="row">Hosts New</th>
+        <td><span class="badge text-bg-info">{{ scan_result.hosts_new }}</span></td>
+      </tr>
+      {% endif %}
       <tr>
         <th scope="row">Total</th>
         <td>{{ scan_result.total_hosts }}</td>

--- a/netbox_ping/templates/netbox_ping/ipaddress_ping_tab.html
+++ b/netbox_ping/templates/netbox_ping/ipaddress_ping_tab.html
@@ -23,11 +23,14 @@
               {% if ping_result.is_skipped %}
                 <span class="badge text-bg-warning">Skipped</span>
               {% elif ping_result.is_stale %}
-                <span class="badge text-bg-warning">Stale</span>
+                <span class="badge" style="background-color:#e67e22;color:#fff;">Stale</span>
               {% elif ping_result.is_reachable %}
                 <span class="badge text-bg-success">Up</span>
               {% else %}
                 <span class="badge text-bg-danger">Down</span>
+              {% endif %}
+              {% if ping_result.is_new %}
+                <span class="badge text-bg-info">New</span>
               {% endif %}
             </td>
           </tr>

--- a/netbox_ping/templates/netbox_ping/pingresult.html
+++ b/netbox_ping/templates/netbox_ping/pingresult.html
@@ -28,11 +28,14 @@
               {% if object.is_skipped %}
                 <span class="badge text-bg-warning">Skipped</span>
               {% elif object.is_stale %}
-                <span class="badge text-bg-warning">Stale</span>
+                <span class="badge" style="background-color:#e67e22;color:#fff;">Stale</span>
               {% elif object.is_reachable %}
                 <span class="badge text-bg-success">Up</span>
               {% else %}
                 <span class="badge text-bg-danger">Down</span>
+              {% endif %}
+              {% if object.is_new %}
+                <span class="badge text-bg-info">New</span>
               {% endif %}
             </td>
           </tr>

--- a/netbox_ping/templates/netbox_ping/pingresult_list.html
+++ b/netbox_ping/templates/netbox_ping/pingresult_list.html
@@ -3,11 +3,15 @@
 {% block extra_controls %}
   <div class="btn-group" role="group" aria-label="Quick filters">
     <a href="{% url 'plugins:netbox_ping:pingresult_list' %}"
-       class="btn btn-sm {% if not request.GET.is_reachable and not request.GET.is_stale and not request.GET.is_skipped %}btn-primary{% else %}btn-outline-secondary{% endif %}">
+       class="btn btn-sm {% if not request.GET.is_reachable and not request.GET.is_stale and not request.GET.is_skipped and not request.GET.is_new %}btn-primary{% else %}btn-outline-secondary{% endif %}">
       All
     </a>
-    <a href="{% url 'plugins:netbox_ping:pingresult_list' %}?is_reachable=true&is_stale=false"
-       class="btn btn-sm {% if request.GET.is_reachable == 'true' %}btn-success{% else %}btn-outline-success{% endif %}">
+    <a href="{% url 'plugins:netbox_ping:pingresult_list' %}?is_new=true"
+       class="btn btn-sm {% if request.GET.is_new == 'true' %}btn-info{% else %}btn-outline-info{% endif %}">
+      <span class="mdi mdi-new-box"></span> New
+    </a>
+    <a href="{% url 'plugins:netbox_ping:pingresult_list' %}?is_reachable=true&is_stale=false&is_new=false"
+       class="btn btn-sm {% if request.GET.is_reachable == 'true' and request.GET.is_new == 'false' %}btn-success{% else %}btn-outline-success{% endif %}">
       <span class="mdi mdi-check-circle"></span> Up
     </a>
     <a href="{% url 'plugins:netbox_ping:pingresult_list' %}?is_reachable=false&is_stale=false"

--- a/netbox_ping/templates/netbox_ping/prefix_ping_tab.html
+++ b/netbox_ping/templates/netbox_ping/prefix_ping_tab.html
@@ -103,11 +103,14 @@
           <td>
             <span class="badge text-bg-success">{{ scan_result.hosts_up }} up</span>
             <span class="badge text-bg-danger">{{ scan_result.hosts_down }} down</span>
+            {% if scan_result.hosts_new %}
+              <span class="badge text-bg-info">{{ scan_result.hosts_new }} new</span>
+            {% endif %}
             {% if scan_result.hosts_stale %}
-              <span class="badge text-bg-warning">{{ scan_result.hosts_stale }} stale</span>
+              <span class="badge" style="background-color:#e67e22;color:#fff;">{{ scan_result.hosts_stale }} stale</span>
             {% endif %}
             {% if scan_result.hosts_skipped %}
-              <span class="badge text-bg-light text-dark">{{ scan_result.hosts_skipped }} skipped</span>
+              <span class="badge text-bg-warning">{{ scan_result.hosts_skipped }} skipped</span>
             {% endif %}
             <span class="text-muted ms-1">/ {{ scan_result.total_hosts }} total</span>
           </td>

--- a/netbox_ping/templates/netbox_ping/settings.html
+++ b/netbox_ping/templates/netbox_ping/settings.html
@@ -139,6 +139,37 @@
     </div>
   </div>
 
+  {# ── New IP Badge ── #}
+  <div class="row mb-4">
+    <div class="col-md-6">
+      <div class="card h-100">
+        <h5 class="card-header">
+          <span class="mdi mdi-new-box"></span> New IP Badge
+        </h5>
+        <div class="card-body">
+          {% for field in form %}
+            {% if field.name == 'new_ip_days_threshold' %}
+            <div class="mb-3">
+              <label for="{{ field.id_for_label }}" class="form-label fw-bold">{{ field.label }}</label>
+              {{ field }}
+              {% if field.help_text %}
+              <div class="form-text text-muted">{{ field.help_text }}</div>
+              {% endif %}
+              {% for error in field.errors %}
+              <div class="text-danger">{{ error }}</div>
+              {% endfor %}
+            </div>
+            {% endif %}
+          {% endfor %}
+          <div class="form-text text-muted">
+            Auto-discovered IPs will show a <span class="badge text-bg-info">New</span> badge
+            for this many days after discovery. Set to 0 to disable.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
   {# ── Email Notifications ── #}
   <div class="row mb-4">
     <div class="col-12">

--- a/netbox_ping/templates/netbox_ping/subnetscanresult.html
+++ b/netbox_ping/templates/netbox_ping/subnetscanresult.html
@@ -34,16 +34,22 @@
             <th scope="row">Hosts Down</th>
             <td><span class="badge text-bg-danger">{{ object.hosts_down }}</span></td>
           </tr>
+          {% if object.hosts_new %}
+          <tr>
+            <th scope="row">Hosts New</th>
+            <td><span class="badge text-bg-info">{{ object.hosts_new }}</span></td>
+          </tr>
+          {% endif %}
           {% if object.hosts_stale %}
           <tr>
             <th scope="row">Hosts Stale</th>
-            <td><span class="badge text-bg-warning">{{ object.hosts_stale }}</span></td>
+            <td><span class="badge" style="background-color:#e67e22;color:#fff;">{{ object.hosts_stale }}</span></td>
           </tr>
           {% endif %}
           {% if object.hosts_skipped %}
           <tr>
             <th scope="row">Hosts Skipped</th>
-            <td><span class="badge text-bg-light text-dark">{{ object.hosts_skipped }}</span></td>
+            <td><span class="badge text-bg-warning">{{ object.hosts_skipped }}</span></td>
           </tr>
           {% endif %}
           <tr>

--- a/netbox_ping/utils.py
+++ b/netbox_ping/utils.py
@@ -429,12 +429,14 @@ def scan_prefix(prefix_obj, dns_servers=None, perform_dns=True, max_workers=100,
     down = tracked - up - skipped - removed
 
     # Count stale IPs (remaining after removal)
+    remaining_ip_pks = [ip.pk for ip in ip_addresses if ip.pk not in ips_to_remove] if ips_to_remove else [ip.pk for ip in ip_addresses]
     stale_count = PingResult.objects.filter(
-        ip_address__in=[ip.pk for ip in ip_addresses],
+        ip_address__in=remaining_ip_pks,
         is_stale=True,
-    ).count() if not ips_to_remove else PingResult.objects.filter(
-        ip_address__in=[ip.pk for ip in ip_addresses if ip.pk not in ips_to_remove],
-        is_stale=True,
+    ).count()
+    new_count = PingResult.objects.filter(
+        ip_address__in=remaining_ip_pks,
+        is_new=True,
     ).count()
 
     SubnetScanResult.objects.update_or_create(
@@ -445,6 +447,7 @@ def scan_prefix(prefix_obj, dns_servers=None, perform_dns=True, max_workers=100,
             'hosts_down': down,
             'hosts_skipped': skipped,
             'hosts_stale': stale_count,
+            'hosts_new': new_count,
             'last_scanned': timezone.now(),
         },
     )
@@ -537,6 +540,8 @@ def discover_prefix(prefix_obj, dns_servers=None, perform_dns=True, max_workers=
                         dns_name=dns_name,
                         last_checked=now,
                         last_seen=now,
+                        is_new=True,
+                        discovered_at=now,
                     )
                     PingHistory.objects.create(
                         ip_address=ip_obj,
@@ -566,12 +571,17 @@ def discover_prefix(prefix_obj, dns_servers=None, perform_dns=True, max_workers=
                 except Exception as e:
                     logger.error(f'Failed to create IP {ip_str}: {e}')
 
+    new_count = PingResult.objects.filter(
+        ip_address__in=list(prefix_obj.get_child_ips().values_list('pk', flat=True)),
+        is_new=True,
+    ).count()
     SubnetScanResult.objects.update_or_create(
         prefix=prefix_obj,
         defaults={
             'total_hosts': len(hosts),
             'hosts_up': total_up,
             'hosts_down': len(hosts) - total_up,
+            'hosts_new': new_count,
             'last_discovered': timezone.now(),
         },
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-ping"
-version = "2.2.1"
+version = "2.3.0"
 description = "A NetBox plugin for pinging and discovering IPs"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Add blue **New** badge on auto-discovered IPs, visible for a configurable number of days (default 7)
- Fix badge colors: **Stale** = dark orange, **Skipped** = yellow (were both the same color before)
- "New" badge shows alongside status badges (e.g. `[Skipped] [New]`, `[Up] [New]`)
- New quick filter tab, settings section, API fields, and migration
- Version bump to **2.3.0**

## Changes
- 18 files changed across models, views, templates, forms, tables, API serializers
- New migration: `0013_new_ip_badge.py`