### PR TITLE
fix: quick search on Ping Results and Ping History matches IPs (#29)

### DIFF
--- a/netbox_ping/filtersets.py
+++ b/netbox_ping/filtersets.py
@@ -24,9 +24,15 @@ class PingResultFilterSet(NetBoxModelFilterSet):
     def search(self, queryset, name, value):
         if not value.strip():
             return queryset
-        return queryset.filter(
-            db_models.Q(dns_name__icontains=value)
-        )
+        # Match against DNS name (own and IPAddress.dns_name) and the IP
+        # address text. Use net_host_contains so '192.168' matches all IPs
+        # within that range (host-based, ignoring mask).
+        q = db_models.Q(dns_name__icontains=value)
+        q |= db_models.Q(ip_address__dns_name__icontains=value)
+        # IP fragment match — '192.168' matches every IP starting with that.
+        # Uses django-netfields' host transform, then plain icontains.
+        q |= db_models.Q(ip_address__address__host__icontains=value)
+        return queryset.filter(q).distinct()
 
 
 class PingHistoryFilterSet(NetBoxModelFilterSet):
@@ -45,9 +51,12 @@ class PingHistoryFilterSet(NetBoxModelFilterSet):
     def search(self, queryset, name, value):
         if not value.strip():
             return queryset
-        return queryset.filter(
-            db_models.Q(dns_name__icontains=value)
-        )
+        # Match against the cached dns_name on the history row, the linked
+        # IPAddress.dns_name, and the IP address text (host fragment).
+        q = db_models.Q(dns_name__icontains=value)
+        q |= db_models.Q(ip_address__dns_name__icontains=value)
+        q |= db_models.Q(ip_address__address__host__icontains=value)
+        return queryset.filter(q).distinct()
 
 
 class SubnetScanResultFilterSet(NetBoxModelFilterSet):


### PR DESCRIPTION
Closes #29

The search box on /plugins/netbox-ping/ping-results/ and /plugins/netbox-ping/ping-history/ only matched against the cached dns_name field, so typing an IP fragment like '192.168' returned zero results.

Both filtersets now match against:
- The row's own cached dns_name
- The linked IPAddress.dns_name (source of truth)
- The IP address as a host string — supports fragments like '192.168' or full IPs like '192.168.0.1'